### PR TITLE
Migration of Mage::log() calls

### DIFF
--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/App.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/App.php
@@ -224,16 +224,8 @@ class App extends AbstractFunction implements \Magento\Migration\Code\Processor\
             return $this;
         }
 
-        $currentIndex = $this->index;
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $this->endIndex);
 
-        while ($currentIndex <= $this->endIndex) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
         $this->tokens[$this->index] = '$this->' . $this->diVariableName;
 
         if (array_key_exists($this->methodName, $this->cacheFunctions)) {

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetModel.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetModel.php
@@ -176,15 +176,7 @@ class GetModel extends AbstractFunction implements \Magento\Migration\Code\Proce
             if ($this->tokens[$indexOfMethodCall][0] == T_WHITESPACE) {
                 $indexOfMethodCall++;
             }
-            $currentIndex = $nextNextIndex;
-            while ($currentIndex < $indexOfMethodCall) {
-                if (is_array($this->tokens[$currentIndex])) {
-                    $this->tokens[$currentIndex][1] = '';
-                } else {
-                    $this->tokens[$currentIndex] = '';
-                }
-                $currentIndex++;
-            }
+            $this->tokenHelper->eraseTokens($this->tokens, $nextNextIndex, $indexOfMethodCall - 1);
         }
         return false;
     }
@@ -251,17 +243,11 @@ class GetModel extends AbstractFunction implements \Magento\Migration\Code\Proce
         if ($this->methodName == null || $this->modelFactoryClass == null) {
             return $this;
         }
-        $indexOfMethodCall = $this->tokenHelper->skipMethodCall($this->tokens, $this->index);
-        $currentIndex = $this->index;
 
-        while ($currentIndex < $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
+        $indexOfMethodCall = $this->tokenHelper->skipMethodCall($this->tokens, $this->index);
+
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall - 1);
+
         //TODO: handle parameter to getModel
         $this->tokens[$this->index] = '$this->' . $this->diVariableName . '->create()';
 

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetSingleton.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetSingleton.php
@@ -192,17 +192,11 @@ class GetSingleton extends AbstractFunction implements \Magento\Migration\Code\P
         if ($this->methodName == null || $this->singletonClass == null) {
             return $this;
         }
-        $indexOfMethodCall = $this->tokenHelper->skipMethodCall($this->tokens, $this->index);
-        $currentIndex = $this->index;
 
-        while ($currentIndex < $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
+        $indexOfMethodCall = $this->tokenHelper->skipMethodCall($this->tokens, $this->index);
+
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall - 1);
+
         $this->tokens[$this->index] = '$this->' . $this->diVariableName;
 
         return $this;

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/Helper.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/Helper.php
@@ -211,21 +211,14 @@ class Helper extends AbstractFunction implements \Magento\Migration\Code\Process
                 T_OBJECT_OPERATOR
             );
         }
-        $currentIndex = $this->index;
+
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall - 1);
 
         //TODO: change the formatting text for '__' call
-        while ($currentIndex < $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
         if ($this->methodName != '__') {
             $this->tokens[$this->index] = '$this->' . $this->diVariableName;
         } else {
-            $this->tokens[$currentIndex][1] = '';
+            $this->tokens[$indexOfMethodCall][1] = '';
         }
 
         return $this;

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/Log.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/Log.php
@@ -1,0 +1,146 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor\Mage\MageFunction;
+
+use Magento\Migration\Code\Processor\Mage\MageFunctionInterface;
+
+class Log extends AbstractFunction implements \Magento\Migration\Code\Processor\Mage\MageFunctionInterface
+{
+    /**
+     * @var string
+     */
+    protected $diClass = '\Psr\Log\LoggerInterface';
+
+    /**
+     * @var string
+     */
+    protected $methodName = 'log';
+
+    /**
+     * @var int
+     */
+    protected $endIndex = null;
+
+    /**
+     * @var string
+     */
+    protected $diVariableName = 'logger';
+
+    /**
+     * @var array
+     */
+    protected $errorLevelMap = [
+        \Zend_Log::EMERG    => '\\Monolog\\Logger::EMERGENCY',
+        \Zend_Log::ALERT    => '\\Monolog\\Logger::ALERT',
+        \Zend_Log::CRIT     => '\\Monolog\\Logger::CRITICAL',
+        \Zend_Log::ERR      => '\\Monolog\\Logger::ERROR',
+        \Zend_Log::WARN     => '\\Monolog\\Logger::WARNING',
+        \Zend_Log::NOTICE   => '\\Monolog\\Logger::NOTICE',
+        \Zend_Log::INFO     => '\\Monolog\\Logger::INFO',
+        \Zend_Log::DEBUG    => '\\Monolog\\Logger::DEBUG',
+    ];
+
+    /**
+     * @inheritdoc
+     */
+    public function getType()
+    {
+        return MageFunctionInterface::MAGE_LOG;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getClass()
+    {
+        return $this->diClass;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getMethod()
+    {
+        return $this->methodName;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getStartIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getEndIndex()
+    {
+        return $this->index + 2;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function convertToM2()
+    {
+        $indexOfMethodCall = $this->index + 2;
+
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall);
+
+        $arguments = $this->tokenHelper->getCallArguments($this->tokens, $this->index);
+        $count = $arguments->getCount();
+        if ($count == 1) {
+            //Mage::log($message)
+            $this->tokens[$this->index] = '$this->' . $this->diVariableName . '->debug';
+        } else if ($count > 1) {
+            //Mage::log($message, Zend_Log::INFO)
+            //Mage::log($message, Zend_Log::INFO, 'custom.log')
+            //Mage::log($message, Zend_Log::INFO, 'custom.log', true)
+            $this->tokens[$this->index] = '$this->' . $this->diVariableName . '->log';
+            $errorLevel = $this->convertErrorLevel($arguments->getArgument(2)->getString());
+            $argumentsNew = $errorLevel . ', ' . $arguments->getArgument(1)->getString();
+            $this->tokenHelper->replaceCallArgumentsTokens($this->tokens, $this->index, $argumentsNew);
+            if ($count > 2) {
+                $this->logger->warn('Discarded obsolete arguments of Mage::log()');
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * Convert error level from Zend to PSR format, used in M1 and M2 respectively
+     *
+     * @param mixed $level
+     * @return mixed
+     */
+    protected function convertErrorLevel($level)
+    {
+        $levelValue = defined($level) ? constant($level) : $level;
+        if (array_key_exists($levelValue, $this->errorLevelMap)) {
+            return $this->errorLevelMap[$levelValue];
+        }
+        return $level;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDiVariableName()
+    {
+        return $this->diVariableName;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getDiClass()
+    {
+        return $this->getClass();
+    }
+}

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/LogException.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/LogException.php
@@ -75,17 +75,10 @@ class LogException extends AbstractFunction implements \Magento\Migration\Code\P
     public function convertToM2()
     {
         $indexOfMethodCall = $this->index + 2;
-        $currentIndex = $this->index;
 
-        while ($currentIndex <= $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
-        $this->tokens[$this->index] = '$this->logger->critical';
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall);
+
+        $this->tokens[$this->index] = '$this->' . $this->diVariableName . '->critical';
 
         return $this;
     }

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/Registry.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/Registry.php
@@ -75,16 +75,9 @@ class Registry extends AbstractFunction implements \Magento\Migration\Code\Proce
     public function convertToM2()
     {
         $indexOfMethodCall = $this->index + 2;
-        $currentIndex = $this->index;
 
-        while ($currentIndex < $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall - 1);
+
         $this->tokens[$this->index] = '$this->' . $this->diVariableName . '->';
 
         return $this;

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/ThrowException.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/ThrowException.php
@@ -75,16 +75,9 @@ class ThrowException extends AbstractFunction implements \Magento\Migration\Code
     public function convertToM2()
     {
         $indexOfMethodCall = $this->index + 2;
-        $currentIndex = $this->index;
 
-        while ($currentIndex <= $indexOfMethodCall) {
-            if (is_array($this->tokens[$currentIndex])) {
-                $this->tokens[$currentIndex][1] = '';
-            } else {
-                $this->tokens[$currentIndex] = '';
-            }
-            $currentIndex++;
-        }
+        $this->tokenHelper->eraseTokens($this->tokens, $this->index, $indexOfMethodCall);
+
         $this->tokens[$this->index] = 'throw new \Magento\Framework\Exception\LocalizedException';
 
         return $this;

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunctionInterface.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunctionInterface.php
@@ -15,6 +15,7 @@ interface MageFunctionInterface
     const MAGE_GET_STORE_CONFIG = 'getStoreConfig';
     const MAGE_REGISTRY = 'registry';
     const MAGE_THROW_EXCEPTION = 'throwException';
+    const MAGE_LOG = 'log';
     const MAGE_LOG_EXCEPTION = 'logException';
 
     /**

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunctionMatcher.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunctionMatcher.php
@@ -81,6 +81,12 @@ class MageFunctionMatcher implements MatcherInterface
                 );
                 $throwException->setContext($tokens, $index);
                 return $throwException;
+            case 'log':
+                $log = $this->objectManager->create(
+                    '\Magento\Migration\Code\Processor\Mage\MageFunction\Log'
+                );
+                $log->setContext($tokens, $index);
+                return $log;
             case 'logException':
                 $logException = $this->objectManager->create(
                     '\Magento\Migration\Code\Processor\Mage\MageFunction\LogException'

--- a/src/Magento/Migration/Code/Processor/TokenHelper.php
+++ b/src/Magento/Migration/Code/Processor/TokenHelper.php
@@ -518,7 +518,7 @@ class TokenHelper
      *
      * @param array $tokens
      * @param int $index
-     * @param \Magento\Migration\Code\Processor\TokenArgumentCollection $replacementTokens
+     * @param string|\Magento\Migration\Code\Processor\TokenArgumentCollection $replacementTokens
      * @return $this
      */
     public function replaceCallArgumentsTokens(&$tokens, $index, $replacementTokens)
@@ -539,16 +539,56 @@ class TokenHelper
             return $this;
         }
 
-        $tokens[$indexStart + 1] = [T_CONSTANT_ENCAPSED_STRING, '', $indexStart + 1, 'T_CONSTANT_ENCAPSED_STRING'];
-        foreach ($replacementTokens->getTokens() as $token) {
-            /** @var  \Magento\Migration\Code\Processor\TokenArgument $token */
-            $tokens[$indexStart + 1][1] .= $token->getName();
-        }
+        $tokens[$indexStart + 1] = [
+            T_CONSTANT_ENCAPSED_STRING,
+            $this->renderTokens($replacementTokens),
+            $indexStart + 1,
+            'T_CONSTANT_ENCAPSED_STRING'
+        ];
 
         for ($cnt = $indexStart + 2; $cnt < $indexEnd; $cnt++) {
             $tokens[$cnt] = '';
         }
         return $this;
+    }
+
+    /**
+     * Return string representation of token(s)
+     *
+     * @param string|\Magento\Migration\Code\Processor\TokenArgumentCollection $tokens
+     * @return string
+     */
+    protected function renderTokens($tokens)
+    {
+        if ($tokens instanceof \Magento\Migration\Code\Processor\TokenArgumentCollection) {
+            $result = '';
+            foreach ($tokens->getTokens() as $token) {
+                /** @var \Magento\Migration\Code\Processor\TokenArgument $token */
+                $result .= $token->getName();
+            }
+        } else {
+            $result = (string)$tokens;
+        }
+        return $result;
+    }
+
+    /**
+     * Assign empty value to tokens in a given range
+     *
+     * @param array $tokens
+     * @param int $indexFrom
+     * @param int $indexTo
+     * @return void
+     */
+    public function eraseTokens(array &$tokens, $indexFrom, $indexTo)
+    {
+        for ($i = $indexFrom; $i <= $indexTo; $i++) {
+            if (is_array($tokens[$i])) {
+                $tokens[$i][1] = '';
+            } else {
+                $tokens[$i] = '';
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
- Conversion of `Mage::log('msg')` to `\Psr\Log\LoggerInterface::debug('msg')`
- Conversion of `Mage::log('msg', Zend_Log::WARN)` to `\Psr\Log\LoggerInterface::log(\Monolog\Logger::WARNING, 'msg')`
- Conversion of actual values of `Zend_Log::*` constants as `\Psr\Log\Logger` constants
- Discarding obsolete arguments of `Mage::log()` with the warning
- Introduced `\Magento\Migration\Code\Processor\TokenHelper::eraseTokens()` to reuse token erasing logic
- Overloaded `\Magento\Migration\Code\Processor\TokenHelper::replaceCallArgumentsTokens()` to support string replacement