### PR TITLE
Migration of references to non-native classes

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1049,6 +1049,25 @@
         </arguments>
     </type>
 
+    <type name="Magento\Migration\Code\Processor\ClassProcessor">
+        <arguments>
+            <!-- M1 classes, references to which are to be converted separately by specialized processors -->
+            <argument name="skippedClasses" xsi:type="array">
+                <item name="Mage" xsi:type="string">Mage</item>
+            </argument>
+        </arguments>
+    </type>
+
+    <type name="\Magento\Migration\Code\Processor\ClassNameValidator">
+        <arguments>
+            <argument name="nativeClassPrefixes" xsi:type="array">
+                <item name="Varien" xsi:type="string">Varien</item>
+                <item name="Mage" xsi:type="string">Mage</item>
+                <item name="Enterprise" xsi:type="string">Enterprise</item>
+            </argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Migration\Code\ConfigConverter">
         <arguments>
             <argument name="extractors"  xsi:type="array">

--- a/src/Magento/Migration/Code/Processor/ClassNameValidator.php
+++ b/src/Magento/Migration/Code/Processor/ClassNameValidator.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor;
+
+class ClassNameValidator
+{
+    /**
+     * @var \Magento\Migration\Mapping\Alias
+     */
+    protected $aliasMapper;
+
+    /**
+     * @var array
+     */
+    protected $nativeClassPrefixes = [];
+
+    /**
+     * @var array|null
+     */
+    protected $knownClassPrefixes = null;
+
+    /**
+     * @param \Magento\Migration\Mapping\Alias $aliasMapper
+     * @param array $nativeClassPrefixes
+     */
+    public function __construct(
+        \Magento\Migration\Mapping\Alias $aliasMapper,
+        array $nativeClassPrefixes = []
+    ) {
+        $this->aliasMapper = $aliasMapper;
+        $this->nativeClassPrefixes = $nativeClassPrefixes;
+    }
+
+    /**
+     * @param string $m1ClassName
+     * @return bool
+     */
+    public function isNativeClass($m1ClassName)
+    {
+        return $this->hasClassPrefix($m1ClassName, $this->nativeClassPrefixes);
+    }
+
+    /**
+     * @param string $m1ClassName
+     * @return bool
+     */
+    public function isKnownClass($m1ClassName)
+    {
+        return $this->hasClassPrefix($m1ClassName, $this->getKnownClassPrefixes());
+    }
+
+    /**
+     * @param string $m1ClassName
+     * @param array $prefixes
+     * @return bool
+     */
+    protected function hasClassPrefix($m1ClassName, array $prefixes)
+    {
+        $prefixesEscaped = array_map('preg_quote', $prefixes);
+        $pattern = '/^(?:' . implode('|', $prefixesEscaped) . ')_/';
+        return (bool)preg_match($pattern, $m1ClassName);
+    }
+
+    /**
+     * @return array
+     */
+    protected function getKnownClassPrefixes()
+    {
+        if ($this->knownClassPrefixes === null) {
+            $this->knownClassPrefixes = [];
+            foreach ($this->aliasMapper->getAllMapping() as $map) {
+                $this->knownClassPrefixes += array_values($map);
+            }
+        }
+        return $this->knownClassPrefixes;
+    }
+}

--- a/tests/unit/Magento/Migration/Code/Processor/ClassProcessorTest.php
+++ b/tests/unit/Magento/Migration/Code/Processor/ClassProcessorTest.php
@@ -23,14 +23,14 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
     protected $aliasMapMock;
 
     /**
-     * @var \Magento\Migration\Mapping\Context|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $contextMock;
-
-    /**
      * @var \Magento\Migration\Code\Processor\ConstructorHelperFactory|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $constructorHelperFactoryMock;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\ClassNameValidator|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $classNameValidatorMock;
 
     /**
      * @var \Magento\Migration\Logger\Logger|\PHPUnit_Framework_MockObject_MockObject
@@ -55,13 +55,14 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
         )->disableOriginalConstructor()
             ->getMock();
 
-        $this->contextMock = $this->getMockBuilder(
-            '\Magento\Migration\Mapping\Context'
-        )->getMock();
-
         $this->constructorHelperFactoryMock = $this->getMockBuilder(
             '\Magento\Migration\Code\Processor\ConstructorHelperFactory'
         )->setMethods(['create'])
+            ->getMock();
+
+        $this->classNameValidatorMock = $this->getMockBuilder(
+            '\Magento\Migration\Code\Processor\ClassNameValidator'
+        )->disableOriginalConstructor()
             ->getMock();
 
         $this->tokenHelper = $this->setupTokenHelper($this->loggerMock);
@@ -94,9 +95,9 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
             $this->classMapMock,
             $this->aliasMapMock,
             $this->loggerMock,
-            $this->contextMock,
             $this->constructorHelperFactoryMock,
-            $this->tokenHelper
+            $this->tokenHelper,
+            $this->classNameValidatorMock
         );
     }
 
@@ -166,7 +167,7 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
             ['Varien_Type', '\\Magento\\Framework\\Type'],
             ['Mage_Type_Obsolete', 'obsolete'],
         ];
-        $this->classMapMock->expects($this->exactly(3))
+        $this->classMapMock->expects($this->atLeastOnce())
             ->method('mapM1Class')
             ->willReturnMap($classMap);
 


### PR DESCRIPTION
- Implemented migration of references to classes of 3rd party modules:
  - `class Example extends Vendor_Module_Class1`
  - `class Example implements Vendor_Module_Interface1`
  - `function func(Vendor_Module_Class1 $arg)`
  - `$obj instanceof Vendor_Module_Class1`
  - `Vendor_Module_Class1::method()`
  - `Vendor_Module_Class1::CONST1`
- Prevented migration of references to non-mapped native classes
- Removed hard-coded references to names of native classes
- Fixed excessive suffix `Controller` in converted controller classes
- Resolved #6 References to non-native classes are not converted