### PR TITLE
Object creation via operator "new"

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1038,6 +1038,7 @@
     </type>
     <type name="Magento\Framework\Api\Search\SearchCriteriaBuilder" shared="false"/>
     <type name="Magento\Framework\Api\Search\FilterGroupBuilder" shared="false"/>
+    <type name="Magento\Migration\Code\Processor\ConstructorHelper" shared="false"/>
     <type name="Magento\Migration\Code\Converter">
         <arguments>
             <argument name="processors"  xsi:type="array">
@@ -1045,6 +1046,7 @@
                 <item name="classProcessor" xsi:type="object">Magento\Migration\Code\Processor\ClassProcessor</item>
                 <item name="blockClassProcessor" xsi:type="object">Magento\Migration\Code\Processor\BlockClassProcessor</item>
                 <item name="mageProcessor" xsi:type="object">Magento\Migration\Code\Processor\MageProcessor</item>
+                <item name="operatorNewProcessor" xsi:type="object">Magento\Migration\Code\Processor\OperatorNewProcessor</item>
                 <item name="controllerProcessor" xsi:type="object">Magento\Migration\Code\Processor\ControllerProcessor</item>
             </argument>
         </arguments>

--- a/src/Magento/Migration/Code/Processor/Block/LayoutFunction/CreateBlock.php
+++ b/src/Magento/Migration/Code/Processor/Block/LayoutFunction/CreateBlock.php
@@ -6,6 +6,7 @@
 namespace Magento\Migration\Code\Processor\Block\LayoutFunction;
 
 use Magento\Migration\Code\Processor\Block\AbstractFunction;
+use Magento\Migration\Mapping\Alias;
 
 class CreateBlock extends AbstractFunction
 {
@@ -18,8 +19,8 @@ class CreateBlock extends AbstractFunction
 
         if ($arguments->getFirstArgument()) {
             if ($arguments->getFirstArgument()->getFirstToken()->getType() != T_VARIABLE) {
-                $classAlias = $arguments->getFirstArgument()->getString();
-                $className = $this->namingHelper->getM2ClassName($classAlias, 'block');
+                $classAlias = trim($arguments->getFirstArgument()->getString(), '\'"');
+                $className = $this->getBlockClass($classAlias);
                 if ($className) {
                     $argumentsNew = "'" . $className . "'";
                     for ($i = 2; $i <= $arguments->getCount(); $i++) {
@@ -36,5 +37,16 @@ class CreateBlock extends AbstractFunction
         }
 
         return $this;
+    }
+
+    /**
+     * @param string $m1ClassAlias
+     * @return null|string
+     */
+    protected function getBlockClass($m1ClassAlias)
+    {
+        $m1ClassName = $this->namingHelper->getM1ClassName($m1ClassAlias, Alias::TYPE_BLOCK);
+        $m2ClassName = $this->namingHelper->getM2ClassName($m1ClassName);
+        return $m2ClassName;
     }
 }

--- a/src/Magento/Migration/Code/Processor/ClassNameValidator.php
+++ b/src/Magento/Migration/Code/Processor/ClassNameValidator.php
@@ -72,7 +72,7 @@ class ClassNameValidator
         if ($this->knownClassPrefixes === null) {
             $this->knownClassPrefixes = [];
             foreach ($this->aliasMapper->getAllMapping() as $map) {
-                $this->knownClassPrefixes += array_values($map);
+                $this->knownClassPrefixes = array_merge($this->knownClassPrefixes, array_values($map));
             }
         }
         return $this->knownClassPrefixes;

--- a/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetResourceModel.php
+++ b/src/Magento/Migration/Code/Processor/Mage/MageFunction/GetResourceModel.php
@@ -6,6 +6,7 @@
 namespace Magento\Migration\Code\Processor\Mage\MageFunction;
 
 use Magento\Migration\Code\Processor\Mage\MageFunctionInterface;
+use Magento\Migration\Mapping\Alias;
 
 class GetResourceModel extends AbstractFunction implements \Magento\Migration\Code\Processor\Mage\MageFunctionInterface
 {
@@ -73,8 +74,8 @@ class GetResourceModel extends AbstractFunction implements \Magento\Migration\Co
 
         if ($arguments->getFirstArgument()) {
             if ($arguments->getFirstArgument()->getFirstToken()->getType() != T_VARIABLE) {
-                $classAlias = $arguments->getFirstArgument()->getString();
-                $this->className = $this->namingHelper->getM2FactoryClassName($classAlias, 'resource_model');
+                $classAlias = trim($arguments->getFirstArgument()->getString(), '\'"');
+                $this->className = $this->getFactoryClass($classAlias, Alias::TYPE_RESOURCE_MODEL);
                 if ($this->className) {
                     $this->diVariableName = $this->namingHelper->generateVariableName($this->className);
                 }
@@ -89,6 +90,18 @@ class GetResourceModel extends AbstractFunction implements \Magento\Migration\Co
         $this->methodName = $this->getModelMethod();
 
         $this->endIndex = $this->tokenHelper->skipMethodCall($this->tokens, $this->index) - 1;
+    }
+
+    /**
+     * @param string $m1ClassAlias
+     * @param string $type
+     * @return null|string
+     */
+    protected function getFactoryClass($m1ClassAlias, $type)
+    {
+        $m1ClassName = $this->namingHelper->getM1ClassName($m1ClassAlias, $type);
+        $m2ClassName = $this->namingHelper->getM2FactoryClassName($m1ClassName);
+        return $m2ClassName;
     }
 
     /**

--- a/src/Magento/Migration/Code/Processor/OperatorNewProcessor.php
+++ b/src/Magento/Migration/Code/Processor/OperatorNewProcessor.php
@@ -1,0 +1,202 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor;
+
+class OperatorNewProcessor implements \Magento\Migration\Code\ProcessorInterface
+{
+    /**
+     * @var \Magento\Migration\Code\Processor\TokenHelper
+     */
+    protected $tokenHelper;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\ConstructorHelper
+     */
+    protected $constructorHelper;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\NamingHelper
+     */
+    protected $namingHelper;
+
+    /**
+     * @var string $filePath
+     */
+    protected $filePath;
+
+    /**
+     * @param TokenHelper $tokenHelper
+     * @param ConstructorHelper $constructorHelper
+     * @param NamingHelper $namingHelper
+     */
+    public function __construct(
+        \Magento\Migration\Code\Processor\TokenHelper $tokenHelper,
+        \Magento\Migration\Code\Processor\ConstructorHelper $constructorHelper,
+        \Magento\Migration\Code\Processor\NamingHelper $namingHelper
+    ) {
+        $this->tokenHelper = $tokenHelper;
+        $this->constructorHelper = $constructorHelper;
+        $this->namingHelper = $namingHelper;
+    }
+
+    /**
+     * @param string $filePath
+     * @return $this
+     */
+    public function setFilePath($filePath)
+    {
+        $this->filePath = $filePath;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath()
+    {
+        return $this->filePath;
+    }
+
+    /**
+     * @param array $tokens
+     * @return array
+     */
+    public function process(array $tokens)
+    {
+        $isWithinClass = $this->isClass($tokens);
+
+        $diVariables = [];
+        foreach ($this->findOperatorNewTokens($tokens) as $tokenInfo) {
+            $indexFrom = $tokenInfo['index_from'];
+            $indexTo = $tokenInfo['index_to'];
+            $indexClass = $tokenInfo['index_class'];
+            $m1ClassName = $tokenInfo['class_name'];
+            $isPrecededByThrow = $this->isPrecededByThrow($tokens, $indexFrom);
+            if ($isWithinClass && !$isPrecededByThrow && $this->isFactoryNeeded($m1ClassName)) {
+                $m2ClassName = $this->namingHelper->getM2FactoryClassName($m1ClassName);
+                $variableName = $this->namingHelper->generateVariableName($m2ClassName);
+                $diVariables[$variableName] = [
+                    'variable_name' => $variableName,
+                    'type' => $m2ClassName,
+                ];
+                $this->tokenHelper->eraseTokens($tokens, $indexFrom, $indexTo);
+                $replacement = '$this->' . $variableName . '->create';
+                if (!$this->isFollowedByArguments($tokens, $indexFrom)) {
+                    $replacement .= '()';
+                }
+                //TODO: handle constructor arguments
+            } else {
+                $m2ClassName = $this->namingHelper->getM2ClassName($m1ClassName);
+                $replacement = $m2ClassName;
+            }
+            if ($replacement) {
+                $tokens[$indexClass][1] = $replacement;
+            }
+        }
+
+        if ($diVariables) {
+            $this->constructorHelper->setContext($tokens);
+            $this->constructorHelper->injectArguments($diVariables);
+        }
+
+        $tokens = $this->tokenHelper->refresh($tokens);
+        return $tokens;
+    }
+
+    /**
+     * @param array $tokens
+     * @return array
+     */
+    public function findOperatorNewTokens(array &$tokens)
+    {
+        $result = [];
+        $currentIndex = -1;
+        while ($currentIndex = $this->tokenHelper->getNextIndexOfTokenType($tokens, $currentIndex + 1, T_NEW)) {
+            $nextTokenIndex = $this->tokenHelper->getNextTokenIndex($tokens, $currentIndex);
+            if ($nextTokenIndex === null) {
+                break;
+            }
+            $nextToken = $tokens[$nextTokenIndex];
+            if (is_array($nextToken) && $nextToken[0] == T_STRING) {
+                $m1ClassName = $nextToken[1];
+                $result[] = [
+                    'index_from' => $currentIndex,
+                    'index_to' => $nextTokenIndex,
+                    'index_class' => $nextTokenIndex,
+                    'class_name' => $m1ClassName,
+                ];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Whether a given token is preceded by a throw token on the same line
+     *
+     * @param array $tokens
+     * @param int $currentIndex
+     * @return bool
+     */
+    protected function isPrecededByThrow(array $tokens, $currentIndex)
+    {
+        $throwTokenIndex = $this->tokenHelper->getPrevIndexOfTokenType($tokens, $currentIndex, T_THROW);
+        if ($throwTokenIndex !== null) {
+            $currentLine = $tokens[$currentIndex][2];
+            $throwTokenLine = $tokens[$throwTokenIndex][2];
+            return ($throwTokenLine == $currentLine);
+        }
+        return false;
+    }
+
+    /**
+     * Whether a given token is followed by argument tokens on the same line
+     *
+     * @param array $tokens
+     * @param int $currentIndex
+     * @return bool
+     */
+    protected function isFollowedByArguments(array $tokens, $currentIndex)
+    {
+        try {
+            $argumentsIndex = $this->tokenHelper->getNextIndexOfSimpleToken($tokens, $currentIndex, '(');
+            $currentLine = $tokens[$currentIndex][2];
+            $nextLineIndex = $this->tokenHelper->getNextLineIndex($tokens, $currentIndex, $currentLine);
+            return ($nextLineIndex === null || $nextLineIndex > $argumentsIndex);
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Whether creation of a class instance is to be delegated to a corresponding factory
+     *
+     * @param string $className
+     * @return bool
+     */
+    protected function isFactoryNeeded($className)
+    {
+        $className = ltrim($className, '\\');
+        if (strpos($className, 'Exception') !== false) {
+            return false;
+        }
+        if (strpos($className, 'Zend_') === 0) {
+            return false;
+        }
+        if (strpos($className, '_') === false && strpos($className, '\\') === false) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @param array $tokens
+     * @return bool
+     */
+    protected function isClass(array &$tokens)
+    {
+        return $this->tokenHelper->getNextIndexOfTokenType($tokens, 0, T_CLASS) !== null;
+    }
+}

--- a/src/Magento/Migration/Mapping/Alias.php
+++ b/src/Magento/Migration/Mapping/Alias.php
@@ -8,6 +8,16 @@ namespace Magento\Migration\Mapping;
 
 class Alias
 {
+    /**#@+
+     * Types of class aliases in Magento 1.x
+     */
+    const TYPE_BLOCK            = 'block';
+    const TYPE_HELPER           = 'helper';
+    const TYPE_MODEL            = 'model';
+    const TYPE_RESOURCE_MODEL   = 'resource_model';
+    const TYPE_CONTROLLER       = 'controller';
+    /**#@-*/
+
     /**
      * @var array
      */
@@ -140,19 +150,22 @@ class Alias
     private function getAliasesFromFiles($configFiles)
     {
         $aliases = [
-            'helper' => [],
-            'block' => [],
-            'model' => [],
-            'resource_model' => [],
+            self::TYPE_HELPER => [],
+            self::TYPE_BLOCK => [],
+            self::TYPE_MODEL => [],
+            self::TYPE_RESOURCE_MODEL => [],
+            self::TYPE_CONTROLLER => [],
         ];
         foreach ($configFiles as $configFile) {
             $configFileContent = file_get_contents($configFile);
             $config = new \Magento\Migration\Utility\M1\Config($configFileContent, $this->logger);
+            $moduleName = $config->getModuleName();
             $aliasesInFile = [
-                'helper' => $config->getAliases('helpers'),
-                'block' => $config->getAliases('blocks'),
-                'model' => $config->getAliases('models'),
-                'resource_model' => $config->getResourceModelAliases(),
+                self::TYPE_HELPER => $config->getAliases('helpers'),
+                self::TYPE_BLOCK => $config->getAliases('blocks'),
+                self::TYPE_MODEL => $config->getAliases('models'),
+                self::TYPE_RESOURCE_MODEL => $config->getResourceModelAliases(),
+                self::TYPE_CONTROLLER => $moduleName ? [strtolower($moduleName) => $moduleName] : [],
             ];
             $aliases = array_replace_recursive($aliases, $aliasesInFile);
         }

--- a/src/Magento/Migration/Utility/M1/Config.php
+++ b/src/Magento/Migration/Utility/M1/Config.php
@@ -120,12 +120,12 @@ class Config
     }
 
     /**
-     * @return string
+     * @return null|string
      */
     public function getModuleName()
     {
-        /** @var \SimpleXMLElement[] $childrens */
-        $childrens = $this->config->modules->children();
-        return $childrens[0]->getName();
+        /** @var \SimpleXMLElement[] $children */
+        $children = $this->config->modules->children();
+        return isset($children[0]) ? $children[0]->getName() : null;
     }
 }

--- a/tests/unit/Magento/Migration/Code/Processor/ClassProcessorTest.php
+++ b/tests/unit/Magento/Migration/Code/Processor/ClassProcessorTest.php
@@ -13,24 +13,14 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
     protected $obj;
 
     /**
-     * @var \Magento\Migration\Mapping\ClassMapping|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $classMapMock;
-
-    /**
-     * @var \Magento\Migration\Mapping\Alias|\PHPUnit_Framework_MockObject_MockObject
-     */
-    protected $aliasMapMock;
-
-    /**
      * @var \Magento\Migration\Code\Processor\ConstructorHelperFactory|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $constructorHelperFactoryMock;
 
     /**
-     * @var \Magento\Migration\Code\Processor\ClassNameValidator|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Magento\Migration\Code\Processor\NamingHelper|\PHPUnit_Framework_MockObject_MockObject
      */
-    protected $classNameValidatorMock;
+    protected $namingHelperMock;
 
     /**
      * @var \Magento\Migration\Logger\Logger|\PHPUnit_Framework_MockObject_MockObject
@@ -46,24 +36,25 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
     {
         $this->loggerMock = $this->getMock('\Magento\Migration\Logger\Logger');
 
-        $this->classMapMock = $this->getMockBuilder(
-            '\Magento\Migration\Mapping\ClassMapping'
-        )->disableOriginalConstructor()
-            ->getMock();
-        $this->aliasMapMock = $this->getMockBuilder(
-            '\Magento\Migration\Mapping\Alias'
-        )->disableOriginalConstructor()
-            ->getMock();
-
         $this->constructorHelperFactoryMock = $this->getMockBuilder(
             '\Magento\Migration\Code\Processor\ConstructorHelperFactory'
         )->setMethods(['create'])
             ->getMock();
 
-        $this->classNameValidatorMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\ClassNameValidator'
+        $this->namingHelperMock = $this->getMockBuilder(
+            '\Magento\Migration\Code\Processor\NamingHelper'
         )->disableOriginalConstructor()
             ->getMock();
+
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM2ClassName')
+            ->willReturnMap([
+                ['Magento_Migration_NameSpace_Test', '\\Magento\\Migration\\NameSpace\\Test'],
+                ['Mage_Type', '\\Magento\\Type'],
+                ['Varien_Type', '\\Magento\\Framework\\Type'],
+                ['Mage_EmptyConstructorType', '\\Magento\\EmptyConstructorType'],
+            ]);
 
         $this->tokenHelper = $this->setupTokenHelper($this->loggerMock);
 
@@ -92,12 +83,10 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
             );
 
         $this->obj = new \Magento\Migration\Code\Processor\ClassProcessor(
-            $this->classMapMock,
-            $this->aliasMapMock,
             $this->loggerMock,
             $this->constructorHelperFactoryMock,
             $this->tokenHelper,
-            $this->classNameValidatorMock
+            $this->namingHelperMock
         );
     }
 
@@ -162,15 +151,6 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = token_get_all($fileContent);
 
-        $classMap = [
-            ['Mage_Type', '\\Magento\\Type'],
-            ['Varien_Type', '\\Magento\\Framework\\Type'],
-            ['Mage_Type_Obsolete', 'obsolete'],
-        ];
-        $this->classMapMock->expects($this->atLeastOnce())
-            ->method('mapM1Class')
-            ->willReturnMap($classMap);
-
         $processedTokens = $this->obj->process($tokens);
 
         $updatedContent = $this->tokenHelper->reconstructContent($processedTokens);
@@ -213,14 +193,6 @@ class ClassProcessorTest extends \PHPUnit_Framework_TestCase
 
         $tokens = token_get_all($fileContent);
         $tokens = $this->tokenHelper->refresh($tokens);
-
-        $classMap = [
-            ['Mage_Type', '\\Magento\\Type'],
-            ['Mage_EmptyConstructorType', '\\Magento\\EmptyConstructorType'],
-        ];
-        $this->classMapMock->expects($this->exactly(1))
-            ->method('mapM1Class')
-            ->willReturnMap($classMap);
 
         $processedTokens = $this->obj->process($tokens);
 

--- a/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/GetModelTest.php
+++ b/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/GetModelTest.php
@@ -6,6 +6,8 @@
 namespace Magento\Migration\Code\Processor\Mage\MageFunction;
 
 use Magento\Migration\Code\Processor\Mage\MageFunctionInterface;
+use Magento\Migration\Mapping\Alias;
+
 class GetModelTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -38,6 +40,11 @@ class GetModelTest extends \PHPUnit_Framework_TestCase
      */
     protected $argumentFactoryMock;
 
+    /**
+     * @var \Magento\Migration\Code\Processor\NamingHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $namingHelperMock;
+
     public function setUp()
     {
         $this->loggerMock = $this->getMock('\Magento\Migration\Logger\Logger');
@@ -58,12 +65,40 @@ class GetModelTest extends \PHPUnit_Framework_TestCase
         )->setMethods(['create'])
             ->getMock();
 
+        $this->namingHelperMock = $this->getMockBuilder(
+            '\Magento\Migration\Code\Processor\NamingHelper'
+        )->disableOriginalConstructor()
+            ->getMock();
+
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM1ClassName')
+            ->willReturnMap([
+                ['tax/config_method', Alias::TYPE_MODEL, 'Mage_Tax_Model_Config_Method'],
+                ['Mage_Tax_Model_Rule', Alias::TYPE_MODEL, 'Mage_Tax_Model_Rule'],
+            ]);
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM2FactoryClassName')
+            ->willReturnMap([
+                ['Mage_Tax_Model_Config_Method', '\\Magento\\Tax\\Model\\Config\\MethodFactory'],
+                ['Mage_Tax_Model_Rule', '\\Magento\\Tax\\Model\\RuleFactory'],
+            ]);
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('generateVariableName')
+            ->willReturnMap([
+                ['\\Magento\\Tax\\Model\\Config\\MethodFactory', 'taxConfigMethodFactory'],
+                ['\\Magento\\Tax\\Model\\RuleFactory', 'taxRuleFactory'],
+            ]);
+
         $this->obj = new \Magento\Migration\Code\Processor\Mage\MageFunction\GetModel(
             $this->classMapperMock,
             $this->aliasMapperMock,
             $this->loggerMock,
             $this->tokenHelper,
-            $this->argumentFactoryMock
+            $this->argumentFactoryMock,
+            $this->namingHelperMock
         );
     }
 
@@ -122,14 +157,14 @@ class GetModelTest extends \PHPUnit_Framework_TestCase
                     'start_index' => 31,
                     'end_index' => 36,
                     'method' => 'doSomething',
-                    'class' => '\Magento\Tax\Model\ConfigMethodFactory',
+                    'class' => '\Magento\Tax\Model\Config\MethodFactory',
                     'type' => MageFunctionInterface::MAGE_GET_MODEL,
                     'di_variable_name' => 'taxConfigMethodFactory',
-                    'di_variable_class' => '\Magento\Tax\Model\ConfigMethodFactory',
+                    'di_variable_class' => '\Magento\Tax\Model\Config\MethodFactory',
 
                 ],
                 'm1_class_name' => 'Mage_Tax_Model_Config_Method',
-                'mapped_model_class_name' => '\Magento\Tax\Model\ConfigMethod',
+                'mapped_model_class_name' => '\Magento\Tax\Model\Config\Method',
                 'expected' => 'model_mapped_expected',
             ],
             'model_not_mapped' => [
@@ -139,10 +174,10 @@ class GetModelTest extends \PHPUnit_Framework_TestCase
                     'start_index' => 31,
                     'end_index' => 36,
                     'method' => 'doSomething',
-                    'class' => '\Mage\Tax\Model\Config\MethodFactory',
+                    'class' => '\Magento\Tax\Model\Config\MethodFactory',
                     'type' => MageFunctionInterface::MAGE_GET_MODEL,
                     'di_variable_name' => 'taxConfigMethodFactory',
-                    'di_variable_class' => '\Mage\Tax\Model\Config\MethodFactory',
+                    'di_variable_class' => '\Magento\Tax\Model\Config\MethodFactory',
 
                 ],
                 'm1_class_name' => 'Mage_Tax_Model_Config_Method',

--- a/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/GetSingletonTest.php
+++ b/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/GetSingletonTest.php
@@ -6,6 +6,8 @@
 namespace Magento\Migration\Code\Processor\Mage\MageFunction;
 
 use Magento\Migration\Code\Processor\Mage\MageFunctionInterface;
+use Magento\Migration\Mapping\Alias;
+
 class GetSingletonTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -38,6 +40,11 @@ class GetSingletonTest extends \PHPUnit_Framework_TestCase
      */
     protected $argumentFactoryMock;
 
+    /**
+     * @var \Magento\Migration\Code\Processor\NamingHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $namingHelperMock;
+
     public function setUp()
     {
         $this->loggerMock = $this->getMock('\Magento\Migration\Logger\Logger');
@@ -58,12 +65,40 @@ class GetSingletonTest extends \PHPUnit_Framework_TestCase
         )->setMethods(['create'])
             ->getMock();
 
+        $this->namingHelperMock = $this->getMockBuilder(
+            '\Magento\Migration\Code\Processor\NamingHelper'
+        )->disableOriginalConstructor()
+            ->getMock();
+
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM1ClassName')
+            ->willReturnMap([
+                ['tax/config_method', Alias::TYPE_MODEL, 'Mage_Tax_Model_Config_Method'],
+                ['Mage_Tax_Model_Rule', Alias::TYPE_MODEL, 'Mage_Tax_Model_Rule'],
+            ]);
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM2ClassName')
+            ->willReturnMap([
+                ['Mage_Tax_Model_Config_Method', '\\Magento\\Tax\\Model\\Config\\Method'],
+                ['Mage_Tax_Model_Rule', '\\Magento\\Tax\\Model\\Rule'],
+            ]);
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('generateVariableName')
+            ->willReturnMap([
+                ['\\Magento\\Tax\\Model\\Config\\Method', 'taxConfigMethod'],
+                ['\\Magento\\Tax\\Model\\Rule', 'taxRule'],
+            ]);
+
         $this->obj = new \Magento\Migration\Code\Processor\Mage\MageFunction\GetSingleton(
             $this->classMapperMock,
             $this->aliasMapperMock,
             $this->loggerMock,
             $this->tokenHelper,
-            $this->argumentFactoryMock
+            $this->argumentFactoryMock,
+            $this->namingHelperMock
         );
     }
 
@@ -122,14 +157,14 @@ class GetSingletonTest extends \PHPUnit_Framework_TestCase
                     'start_index' => 31,
                     'end_index' => 36,
                     'method' => 'doSomething',
-                    'class' => '\Magento\Tax\Model\ConfigMethod',
+                    'class' => '\Magento\Tax\Model\Config\Method',
                     'type' => MageFunctionInterface::MAGE_GET_SINGLETON,
                     'di_variable_name' => 'taxConfigMethod',
-                    'di_variable_class' => '\Magento\Tax\Model\ConfigMethod',
+                    'di_variable_class' => '\Magento\Tax\Model\Config\Method',
 
                 ],
                 'm1_class_name' => 'Mage_Tax_Model_Config_Method',
-                'mapped_singleton_class_name' => '\Magento\Tax\Model\ConfigMethod',
+                'mapped_singleton_class_name' => '\Magento\Tax\Model\Config\Method',
                 'expected' => 'singleton_mapped_expected',
             ],
             'singleton_not_mapped' => [
@@ -139,10 +174,10 @@ class GetSingletonTest extends \PHPUnit_Framework_TestCase
                     'start_index' => 31,
                     'end_index' => 36,
                     'method' => 'doSomething',
-                    'class' => '\Mage\Tax\Model\Config\Method',
+                    'class' => '\Magento\Tax\Model\Config\Method',
                     'type' => MageFunctionInterface::MAGE_GET_SINGLETON,
                     'di_variable_name' => 'taxConfigMethod',
-                    'di_variable_class' => '\Mage\Tax\Model\Config\Method',
+                    'di_variable_class' => '\Magento\Tax\Model\Config\Method',
 
                 ],
                 'm1_class_name' => 'Mage_Tax_Model_Config_Method',

--- a/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/HelperTest.php
+++ b/tests/unit/Magento/Migration/Code/Processor/Mage/MageFunction/HelperTest.php
@@ -6,6 +6,8 @@
 namespace Magento\Migration\Code\Processor\Mage\MageFunction;
 
 use Magento\Migration\Code\Processor\Mage\MageFunctionInterface;
+use Magento\Migration\Mapping\Alias;
+
 class HelperTest extends \PHPUnit_Framework_TestCase
 {
     /**
@@ -38,6 +40,11 @@ class HelperTest extends \PHPUnit_Framework_TestCase
      */
     protected $argumentFactoryMock;
 
+    /**
+     * @var \Magento\Migration\Code\Processor\NamingHelper|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $namingHelperMock;
+
     public function setUp()
     {
         $this->loggerMock = $this->getMock('\Magento\Migration\Logger\Logger');
@@ -58,12 +65,34 @@ class HelperTest extends \PHPUnit_Framework_TestCase
         )->setMethods(['create'])
             ->getMock();
 
+        $this->namingHelperMock = $this->getMockBuilder(
+            '\Magento\Migration\Code\Processor\NamingHelper'
+        )->disableOriginalConstructor()
+            ->getMock();
+
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM1ClassName')
+            ->willReturnMap([
+                ['tax', Alias::TYPE_HELPER, 'Mage_Tax_Helper_Data'],
+                ['tax/data', Alias::TYPE_HELPER, 'Mage_Tax_Helper_Data'],
+                ['tax/config', Alias::TYPE_HELPER, 'Mage_Tax_Helper_Config'],
+            ]);
+        $this->namingHelperMock
+            ->expects($this->any())
+            ->method('getM2ClassName')
+            ->willReturnMap([
+                ['Mage_Tax_Helper_Data', '\\Magento\\Tax\\Helper\\Data'],
+                ['Mage_Tax_Helper_Config', '\\Magento\\Tax\\Helper\\Config'],
+            ]);
+
         $this->obj = new \Magento\Migration\Code\Processor\Mage\MageFunction\Helper(
             $this->classMapperMock,
             $this->aliasMapperMock,
             $this->loggerMock,
             $this->tokenHelper,
-            $this->argumentFactoryMock
+            $this->argumentFactoryMock,
+            $this->namingHelperMock
         );
     }
 
@@ -184,10 +213,10 @@ class HelperTest extends \PHPUnit_Framework_TestCase
                     'start_index' => 31,
                     'end_index' => 36,
                     'method' => 'doSomething',
-                    'class' => '\Mage\Tax\Helper\Config',
+                    'class' => '\Magento\Tax\Helper\Config',
                     'type' => MageFunctionInterface::MAGE_HELPER,
                     'di_variable_name' => 'taxConfigHelper',
-                    'di_variable_class' => '\Mage\Tax\Helper\Config',
+                    'di_variable_class' => '\Magento\Tax\Helper\Config',
 
                 ],
                 'mapped_helper_class' => null,


### PR DESCRIPTION
- Implemented migration of object instantiation via operator `new`:
  - Replacement of `new` within a class with DI of corresponding factory
  - Replacement of class name in `new` outside of a class
  - Replacement of class name in `throw new`
- Reused class name conversion and variable name generation logic across:
  - `Mage::getModel()`
  - `Mage::getResourceModel()`
  - `Mage::getSingleton()`
  - `Mage::helper()`
  - `Mage_Core_Model_Layout::createBlock()`
  - Arguments, static calls, constants, `instanceof`, `class`, `extends`, `new`
- Fixed variable name generation for `\Magento\Framework\*` classes
- Fixed merging of class prefixes declared in config to not lose data
- Implemented recognition of controller classes based on module names
- Implemented ability to resolve M1 class or alias to M2 class or factory
- Introduced constants for types of class aliases in M1
- Moved processing of quoted arguments out of class name conversion
- Fixed parsing of configs that do not declare a module name
- Resolved #15 Object creation via operator "new" is not converted