### PR TITLE
Migration of model _init call on _construct

### DIFF
--- a/app/etc/di.xml
+++ b/app/etc/di.xml
@@ -1045,6 +1045,7 @@
                 <item name="TableProcessor" xsi:type="object">Magento\Migration\Code\Processor\TableProcessor</item>
                 <item name="docBlockProcessor" xsi:type="object">Magento\Migration\Code\Processor\DocBlockProcessor</item>
                 <item name="classProcessor" xsi:type="object">Magento\Migration\Code\Processor\ClassProcessor</item>
+                <item name="modelClassProcessor" xsi:type="object">Magento\Migration\Code\Processor\ModelClassProcessor</item>
                 <item name="blockClassProcessor" xsi:type="object">Magento\Migration\Code\Processor\BlockClassProcessor</item>
                 <item name="mageProcessor" xsi:type="object">Magento\Migration\Code\Processor\MageProcessor</item>
                 <item name="operatorNewProcessor" xsi:type="object">Magento\Migration\Code\Processor\OperatorNewProcessor</item>

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethod/AbstractMethod.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethod/AbstractMethod.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor\Model\ModelMethod;
+
+use Magento\Migration\Code\Processor\Model\ModelMethodInterface;
+
+abstract class AbstractMethod implements ModelMethodInterface
+{
+    /**
+     * @var \Magento\Migration\Logger\Logger
+     */
+    protected $logger;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\TokenHelper
+     */
+    protected $tokenHelper;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\NamingHelper
+     */
+    protected $namingHelper;
+
+    /**
+     * @var array
+     */
+    protected $tokens;
+
+    /**
+     * @var int
+     */
+    protected $index;
+
+    /**
+     * @param \Magento\Migration\Logger\Logger $logger
+     * @param \Magento\Migration\Code\Processor\TokenHelper $tokenHelper
+     * @param \Magento\Migration\Code\Processor\NamingHelper $namingHelper
+     */
+    public function __construct(
+        \Magento\Migration\Logger\Logger $logger,
+        \Magento\Migration\Code\Processor\TokenHelper $tokenHelper,
+        \Magento\Migration\Code\Processor\NamingHelper $namingHelper
+    ) {
+        $this->logger = $logger;
+        $this->tokenHelper = $tokenHelper;
+        $this->namingHelper = $namingHelper;
+    }
+
+    /**
+     * @param array $tokens
+     * @param int $index
+     * @return void
+     */
+    public function setContext(array &$tokens, $index = 0)
+    {
+        $this->tokens = &$tokens;
+        $this->index = $index;
+    }
+}

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethod/Init.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethod/Init.php
@@ -6,6 +6,7 @@
 namespace Magento\Migration\Code\Processor\Model\ModelMethod;
 
 use Magento\Migration\Code\Processor\Model\ModelMethodInterface;
+use Magento\Migration\Mapping\Alias;
 
 class Init extends AbstractMethod implements ModelMethodInterface
 {
@@ -17,9 +18,8 @@ class Init extends AbstractMethod implements ModelMethodInterface
         $arguments = $this->tokenHelper->getCallArguments($this->tokens, $this->index);
         if ($arguments->getFirstArgument()) {
             if ($arguments->getFirstArgument()->getFirstToken()->getType() != T_VARIABLE) {
-                $classAlias = $arguments->getFirstArgument()->getString();
-                $className = $this->namingHelper->getM2ClassName($classAlias, 'model');
-
+                $classAlias = trim($arguments->getFirstArgument()->getString(), '\'"');
+                $className = $this->getResourceModelClass($classAlias);
                 if ($className) {
                     $argumentsNew = "'" . ltrim($className, '\\') . "'";
                     for ($i = 2; $i <= $arguments->getCount(); $i++) {
@@ -29,12 +29,23 @@ class Init extends AbstractMethod implements ModelMethodInterface
                 }
             } else {
                 $this->logger->warn(sprintf(
-                    'Variable inside a Mage_Core_Model_Layout::createModel call not converted at %s',
+                    'Variable inside a Mage_Core_Model_Abstract::_init call not converted at %s',
                     $arguments->getFirstArgument()->getFirstToken()->getLine()
                 ));
             }
         }
 
         return $this;
+    }
+
+    /**
+     * @param string $m1ClassAlias
+     * @return null|string
+     */
+    protected function getResourceModelClass($m1ClassAlias)
+    {
+        $m1ClassName = $this->namingHelper->getM1ClassName($m1ClassAlias, Alias::TYPE_RESOURCE_MODEL);
+        $m2ClassName = $this->namingHelper->getM2ClassName($m1ClassName);
+        return $m2ClassName;
     }
 }

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethod/Init.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethod/Init.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor\Model\ModelMethod;
+
+use Magento\Migration\Code\Processor\Model\ModelMethodInterface;
+
+class Init extends AbstractMethod implements ModelMethodInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function convertToM2()
+    {
+        $arguments = $this->tokenHelper->getCallArguments($this->tokens, $this->index);
+        if ($arguments->getFirstArgument()) {
+            if ($arguments->getFirstArgument()->getFirstToken()->getType() != T_VARIABLE) {
+                $classAlias = $arguments->getFirstArgument()->getString();
+                $className = $this->namingHelper->getM2ClassName($classAlias, 'model');
+
+                if ($className) {
+                    $argumentsNew = "'" . ltrim($className, '\\') . "'";
+                    for ($i = 2; $i <= $arguments->getCount(); $i++) {
+                        $argumentsNew .= ', ' . $arguments->getArgument($i)->getString();
+                    }
+                    $this->tokenHelper->replaceCallArgumentsTokens($this->tokens, $this->index, $argumentsNew);
+                }
+            } else {
+                $this->logger->warn(sprintf(
+                    'Variable inside a Mage_Core_Model_Layout::createModel call not converted at %s',
+                    $arguments->getFirstArgument()->getFirstToken()->getLine()
+                ));
+            }
+        }
+
+        return $this;
+    }
+}

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethodInterface.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethodInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor\Model;
+
+interface ModelMethodInterface
+{
+    /**
+     * @param array $tokens
+     * @param int $index
+     * @return $this
+     */
+    public function setContext(array &$tokens, $index = 0);
+
+    /**
+     * @return $this
+     */
+    public function convertToM2();
+}

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethodMatcher.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethodMatcher.php
@@ -43,11 +43,6 @@ class ModelMethodMatcher implements \Magento\Migration\Code\Processor\Mage\Match
         $indexOfMethodCall = $this->tokenHelper->getNextIndexOfTokenType($tokens, $index, T_STRING);
         $methodName = $tokens[$indexOfMethodCall][1];
 
-
-        if ($methodName != '_init') {
-            return null;
-        }
-
         switch ($methodName) {
             case '_init':
                 /** @var \Magento\Migration\Code\Processor\Model\ModelMethod\Init $result */

--- a/src/Magento/Migration/Code/Processor/Model/ModelMethodMatcher.php
+++ b/src/Magento/Migration/Code/Processor/Model/ModelMethodMatcher.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor\Model;
+
+class ModelMethodMatcher implements \Magento\Migration\Code\Processor\Mage\MatcherInterface
+{
+    /**
+     * @var \Magento\Framework\ObjectManagerInterface
+     */
+    protected $objectManager;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\TokenHelper
+     */
+    protected $tokenHelper;
+
+    /**
+     * @param \Magento\Framework\ObjectManagerInterface $objectManager
+     * @param \Magento\Migration\Code\Processor\TokenHelper $tokenHelper
+     */
+    public function __construct(
+        \Magento\Framework\ObjectManagerInterface $objectManager,
+        \Magento\Migration\Code\Processor\TokenHelper $tokenHelper
+    ) {
+        $this->objectManager = $objectManager;
+        $this->tokenHelper = $tokenHelper;
+    }
+
+    /**
+     * @param array $tokens
+     * @param int $index
+     * @return \Magento\Migration\Code\Processor\Model\ModelMethodInterface|null
+     */
+    public function match(&$tokens, $index)
+    {
+        if (!($this->isVariable($tokens, $index, '$this') && $this->isObjectOperator($tokens, $index + 1))) {
+            return null;
+        }
+
+        $indexOfMethodCall = $this->tokenHelper->getNextIndexOfTokenType($tokens, $index, T_STRING);
+        $methodName = $tokens[$indexOfMethodCall][1];
+
+
+        if ($methodName != '_init') {
+            return null;
+        }
+
+        switch ($methodName) {
+            case '_init':
+                /** @var \Magento\Migration\Code\Processor\Model\ModelMethod\Init $result */
+                $result = $this->objectManager->create(
+                    '\Magento\Migration\Code\Processor\Model\ModelMethod\Init'
+                );
+                $result->setContext($tokens, $index);
+                return $result;
+
+            default:
+                return null;
+        }
+    }
+
+    /**
+     * @param array $tokens
+     * @param int $index
+     * @param string $variableName
+     * @return bool
+     */
+    protected function isVariable(&$tokens, $index, $variableName)
+    {
+        return (is_array($tokens[$index]) && $tokens[$index][0] == T_VARIABLE && $tokens[$index][1] == $variableName);
+    }
+
+    /**
+     * @param array $tokens
+     * @param int $index
+     * @return bool
+     */
+    protected function isObjectOperator(&$tokens, $index)
+    {
+        return (is_array($tokens[$index]) && $tokens[$index][0] == T_OBJECT_OPERATOR);
+    }
+}

--- a/src/Magento/Migration/Code/Processor/ModelClassProcessor.php
+++ b/src/Magento/Migration/Code/Processor/ModelClassProcessor.php
@@ -10,10 +10,8 @@ class ModelClassProcessor implements \Magento\Migration\Code\ProcessorInterface
     /**#@+
      * Patterns that match model class names
      */
-    const MODEL_CLASS_UNDERSCORE            = '/^[^_]+_[^_]+_Model_/';
-    const RESOURCE_MODEL_CLASS_UNDERSCORE   = '/^[^_]+_[^_]+_Model_Resource_/';
-    const MODEL_CLASS_NAMESPACE             = '/^\\\\?[^\\\\]+\\\\[^\\\\]+\\\\Model\\\\/';
-    const RESOURCE_MODEL_CLASS_NAMESPACE    = '/^\\\\?[^\\\\]+\\\\[^\\\\]+\\\\Model\\\\ModelResource\\\\/';
+    const MODEL_CLASS_UNDERSCORE    = '/^[^_]+_[^_]+_Model_(?!Resource_|Mysql4_)/';
+    const MODEL_CLASS_NAMESPACE     = '/^\\\\?[^\\\\]+\\\\[^\\\\]+\\\\Model\\\\(?!ResourceModel\\\\)/';
     /**#@-*/
 
     /**
@@ -89,11 +87,8 @@ class ModelClassProcessor implements \Magento\Migration\Code\ProcessorInterface
     {
         $parentClass = $this->tokenHelper->getExtendsClass($tokens);
         if ($parentClass) {
-            $matchesModel = preg_match(self::MODEL_CLASS_UNDERSCORE, $parentClass)
-                         || preg_match(self::MODEL_CLASS_NAMESPACE, $parentClass);
-            $matchesResourceModel = preg_match(self::RESOURCE_MODEL_CLASS_UNDERSCORE, $parentClass)
-                                 || preg_match(self::RESOURCE_MODEL_CLASS_NAMESPACE, $parentClass);
-            return $matchesModel && !$matchesResourceModel;
+            return preg_match(self::MODEL_CLASS_UNDERSCORE, $parentClass)
+                || preg_match(self::MODEL_CLASS_NAMESPACE, $parentClass);
         }
         return false;
     }

--- a/src/Magento/Migration/Code/Processor/ModelClassProcessor.php
+++ b/src/Magento/Migration/Code/Processor/ModelClassProcessor.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * Copyright © 2015 Magento. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Magento\Migration\Code\Processor;
+
+class ModelClassProcessor implements \Magento\Migration\Code\ProcessorInterface
+{
+    /**#@+
+     * Patterns that match model class names
+     */
+    const MODEL_CLASS_UNDERSCORE            = '/^[^_]+_[^_]+_Model_/';
+    const RESOURCE_MODEL_CLASS_UNDERSCORE   = '/^[^_]+_[^_]+_Model_Resource_/';
+    const MODEL_CLASS_NAMESPACE             = '/^\\\\?[^\\\\]+\\\\[^\\\\]+\\\\Model\\\\/';
+    const RESOURCE_MODEL_CLASS_NAMESPACE    = '/^\\\\?[^\\\\]+\\\\[^\\\\]+\\\\Model\\\\ModelResource\\\\/';
+    /**#@-*/
+
+    /**
+     * @var string $filePath
+     */
+    protected $filePath;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\Mage\MatcherInterface
+     */
+    protected $matcher;
+
+    /**
+     * @var \Magento\Migration\Code\Processor\TokenHelper
+     */
+    protected $tokenHelper;
+
+    /**
+     * @param Model\ModelMethodMatcher $matcher
+     * @param TokenHelper $tokenHelper
+     */
+    public function __construct(
+        \Magento\Migration\Code\Processor\Model\ModelMethodMatcher $matcher,
+        \Magento\Migration\Code\Processor\TokenHelper $tokenHelper
+    ) {
+        $this->matcher = $matcher;
+        $this->tokenHelper = $tokenHelper;
+    }
+
+    /**
+     * @param string $filePath
+     * @return $this
+     */
+    public function setFilePath($filePath)
+    {
+        $this->filePath = $filePath;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath()
+    {
+        return $this->filePath;
+    }
+
+    /**
+     * @param array $tokens
+     * @return array
+     */
+    public function process(array $tokens)
+    {
+        if (!$this->isModelClass($tokens)) {
+            return $tokens;
+        }
+
+        for ($index = 0; $index < count($tokens) - 3; $index++) {
+            $matchedMethod = $this->matcher->match($tokens, $index);
+            if ($matchedMethod) {
+                $matchedMethod->convertToM2();
+            }
+        }
+        $tokens = $this->tokenHelper->refresh($tokens);
+        return $tokens;
+    }
+
+    /**
+     * @param array $tokens
+     * @return bool
+     */
+    protected function isModelClass(array &$tokens)
+    {
+        $parentClass = $this->tokenHelper->getExtendsClass($tokens);
+        if ($parentClass) {
+            $matchesModel = preg_match(self::MODEL_CLASS_UNDERSCORE, $parentClass)
+                         || preg_match(self::MODEL_CLASS_NAMESPACE, $parentClass);
+            $matchesResourceModel = preg_match(self::RESOURCE_MODEL_CLASS_UNDERSCORE, $parentClass)
+                                 || preg_match(self::RESOURCE_MODEL_CLASS_NAMESPACE, $parentClass);
+            return $matchesModel && !$matchesResourceModel;
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
- Implemented migration of `$this->_init()` calls in model classes
- Introduced processor, matcher, and method classes for model classes
- Current processor matches only models; not resource models or collections
- Resolved #8 Initialization of model with resource model is not converted
