### PR TITLE
Function getM1ClassName fails for M1 Class Aliases that don't have _ …

### DIFF
--- a/src/Magento/Migration/Code/Processor/NamingHelper.php
+++ b/src/Magento/Migration/Code/Processor/NamingHelper.php
@@ -61,7 +61,11 @@ class NamingHelper
                 $this->logger->warn(sprintf('Class not found for alias "%s"', $m1ModuleAlias));
                 return null;
             }
-            $m1ClassSuffix = ucwords($m1ClassSuffix, '_');
+            if (strpos($m1ClassSuffix, '_') === false) {
+                $m1ClassSuffix = ucfirst($m1ClassSuffix);
+            } else {
+                $m1ClassSuffix = ucwords($m1ClassSuffix, '_');
+            }
             $result = $m1ClassPrefix . '_' . $m1ClassSuffix;
         }
         return $result;


### PR DESCRIPTION
…in it

The following $m1ClassAlias 

"adminhtml/session"

resulted in 

Mage_Adminhtml_Model_

The above patch fixes this as ucwords returns "NULL" if the delimiter (_) is not found in the string.