### PR TITLE
Fix of installation on Travis CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "fabpot/php-cs-fixer": "~1.2"
     },
     "config": {
-        "use-include-path": true
+        "use-include-path": true,
+        "secure-http": false
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- Allowed to download Composer packages via HTTP besides HTTPS
- Fixed error "Your configuration does not allow connections to http://pear.php.net/..."