### PR TITLE
Fix generateAliasMapping call instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,6 @@ Run the following to regenerate the mapping files:
 
 * `php bin/utils.php generateViewMapping <m1> <m2>` - Regenerate `mapping/view_mapping_adminhtml.json` and `mapping/view_mapping_frontend.json`, `mapping/references.xml`
 
-* `php bin/migrate.php generateAliasMapping <m1> <m2>` - Regenerate `mapping/aliases.json`
+* `php bin/migrate.php generateAliasMapping <m1>` - Regenerate `mapping/aliases.json`
 
-* `php bin/migrate.php generateAliasMappingEE <m1> <m2>` - Regenerate `mapping/aliases_ee.json`
+* `php bin/migrate.php generateAliasMappingEE <m1>` - Regenerate `mapping/aliases_ee.json`


### PR DESCRIPTION
At the time of creating this issue, the `bin/migrate.php` calls `generateAliasMapping` and `generateAliasMappingEE` only take one argument, see https://github.com/magento/code-migration/blob/d4b6705085a2d6247ec61b7839f0829cf3f16762/src/Magento/Migration/Command/GenerateAliasMapping.php#L40 and https://github.com/magento/code-migration/blob/d4b6705085a2d6247ec61b7839f0829cf3f16762/src/Magento/Migration/Command/GenerateAliasMappingEE.php#L40.