### PR TITLE
Fixes unmapped module exceptions

### DIFF
--- a/src/Magento/Migration/Internal/Command/GenerateModuleMapping.php
+++ b/src/Magento/Migration/Internal/Command/GenerateModuleMapping.php
@@ -17,6 +17,10 @@ class GenerateModuleMapping extends Command
      * @var array
      */
     protected $moduleMapping = [
+        "Mage_Sendfriend" => "Magento_SendFriend",
+        "Mage_Uploader" => [
+            "comment" => "obsolete",
+        ],  
         "Enterprise_Catalog" => "Magento_AdvancedCatalog",
         "Enterprise_Checkout" => "Magento_AdvancedCheckout",
         "Enterprise_CatalogInventory" => [


### PR DESCRIPTION
Fixes:

[Exception] unmapped module: Mage_Sendfriend  
[Exception] unmapped module: Mage_Uploader 

when running 

php bin/utils.php generateModuleMapping <src> <dst>

see: https://github.com/magento/code-migration/issues/71