### PR TITLE
Fixes moduleName not found in convertPhpCode

### DIFF
--- a/src/Magento/Migration/Utility/M1/Config.php
+++ b/src/Magento/Migration/Utility/M1/Config.php
@@ -125,7 +125,11 @@ class Config
     public function getModuleName()
     {
         /** @var \SimpleXMLElement[] $children */
-        $children = $this->config->modules->children();
-        return isset($children[0]) ? $children[0]->getName() : null;
+        $moduleName = null;
+        if(is_array($this->config->modules) && count($this->config->modules)) {
+          $children = $this->config->modules->children();
+          $moduleName = isset($children[0]) ? $children[0]->getName() : null;
+        }   
+        return $moduleName;
     }
 }


### PR DESCRIPTION
Added defensive coding to getModuleName() function.

Fatal error received when running:

php bin/migrate.php convertPhpCode <dst> <m1> <m2> 

PHP Fatal error:  Call to a member function children() on a non-object

Previously there was no check for module before calling children() function. 

Solves:

https://github.com/magento/code-migration/issues/88
https://github.com/magento/code-migration/issues/56
https://github.com/magento/code-migration/issues/44



