### PR TITLE
Test enhancement for part of classes

### DIFF
--- a/tests/unit/Magento/Migration/Code/ConverterTest.php
+++ b/tests/unit/Magento/Migration/Code/ConverterTest.php
@@ -5,6 +5,8 @@
  */
 namespace Magento\Migration\Code;
 
+use Magento\Migration\Logger\Logger;
+
 class ConverterTest extends TestCase
 {
     /**
@@ -26,18 +28,18 @@ class ConverterTest extends TestCase
      */
     protected $loggerMock;
 
-    public function setUp()
+    protected function setUp(): void
     {
-        $this->processorMock = $this->getMockBuilder('Magento\Migration\Code\ProcessorInterface')
+        $this->processorMock = $this->getMockBuilder(ProcessorInterface::class)
             ->getMockForAbstractClass();
-        $this->splitterMock = $this->getMockBuilder('Magento\Migration\Code\SplitterInterface')
+        $this->splitterMock = $this->getMockBuilder(SplitterInterface::class)
             ->getMockForAbstractClass();
-        $this->loggerMock = $this->getMockBuilder('\Magento\Migration\Logger\Logger')
+        $this->loggerMock = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()->getMock();
 
         $tokenHelper = $this->setupTokenHelper($this->loggerMock);
 
-        $this->obj = new \Magento\Migration\Code\Converter(
+        $this->obj = new Converter(
             [$this->processorMock],
             [$this->splitterMock],
             $tokenHelper,
@@ -45,7 +47,7 @@ class ConverterTest extends TestCase
         );
     }
 
-    public function testConvert()
+    public function testConvert(): void
     {
         $content = file_get_contents(__DIR__ . '/_files/test.php');
 

--- a/tests/unit/Magento/Migration/Code/ModuleMigrationTest.php
+++ b/tests/unit/Magento/Migration/Code/ModuleMigrationTest.php
@@ -5,12 +5,20 @@
  */
 namespace Magento\Migration\Code;
 
-use Magento\Migration\Code\ModuleMigration;
+use Magento\Framework\TestFramework\Unit\Helper\ObjectManager;
+use Magento\Migration\Logger\Logger;
+use Magento\Migration\Code\ModuleMigration\ModuleFileExtractorFactory;
+use Magento\Migration\Code\ModuleMigration\ModuleFileCopierFactory;
+use Magento\Migration\Utility\M1\ModuleEnablerConfigFactory;
+use Magento\Migration\Code\ModuleMigration\ModuleFileCopier;
+use Magento\Migration\Code\ModuleMigration\ModuleFileExtractor;
+use Magento\Migration\Utility\M1\ModuleEnablerConfig;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ModuleMigrationTest
  */
-class ModuleMigrationTest extends \PHPUnit\Framework\TestCase
+class ModuleMigrationTest extends TestCase
 {
     /**
      * @var \Magento\Migration\Code\ModuleMigration
@@ -49,26 +57,22 @@ class ModuleMigrationTest extends \PHPUnit\Framework\TestCase
     /**
      * Setup the test
      */
-    protected function setUp()
+    protected function setUp(): void
     {
-        $this->objectManager = new \Magento\Framework\TestFramework\Unit\Helper\ObjectManager($this);
+        $this->objectManager = new ObjectManager($this);
 
-        $className = '\Magento\Migration\Logger\Logger';
-        $this->logger = $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+        $this->logger = $this->getMockBuilder(Logger::class)->disableOriginalConstructor()->getMock();
 
-        $className = '\Magento\Migration\Code\ModuleMigration\ModuleFileExtractorFactory';
-        $this->moduleFileExtractorFactory = $this->getMockBuilder($className)->setMethods(['create'])->getMock();
+        $this->moduleFileExtractorFactory = $this->getMockBuilder(ModuleFileExtractorFactory::class)->setMethods(['create'])->getMock();
 
-        $className = '\Magento\Migration\Code\ModuleMigration\ModuleFileCopierFactory';
-        $this->moduleFileCopierFactory = $this->getMockBuilder($className)->setMethods(['create'])->getMock();
+        $this->moduleFileCopierFactory = $this->getMockBuilder(ModuleFileCopierFactory::class)->setMethods(['create'])->getMock();
 
-        $className = '\Magento\Migration\Utility\M1\ModuleEnablerConfigFactory';
-        $this->moduleEnablerConfigFactory = $this->getMockBuilder($className)->setMethods(['create'])->getMock();
+        $this->moduleEnablerConfigFactory = $this->getMockBuilder(ModuleEnablerConfigFactory::class)->setMethods(['create'])->getMock();
 
         $this->m2Path = '/path/to/m2';
 
         $this->model = $this->objectManager->getObject(
-            '\Magento\Migration\Code\ModuleMigration',
+            ModuleMigration::class,
             [
                 'logger' => $this->logger,
                 'moduleFileExtractorFactory' => $this->moduleFileExtractorFactory,
@@ -85,19 +89,16 @@ class ModuleMigrationTest extends \PHPUnit\Framework\TestCase
      * @param string $codePool
      * test MoveModuleFiles
      */
-    public function testMoveModuleFiles($namespaces, $codePool)
+    public function testMoveModuleFiles(array $namespaces, string $codePool): void
     {
         $arrayBlockFiles = ['Block' => [$this->m2Path . '/app/code/Vendor1/Module1/Block/file1']];
         $arrayFrontendXMLFiles = ['frontendXml' => [$this->m2Path . '/app/code/Vendor1/Module1/Block/file2']];
 
-        $className = '\Magento\Migration\Code\ModuleMigration\ModuleFileCopier';
-        $moduleFileCopier = $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+        $moduleFileCopier = $this->getMockBuilder(ModuleFileCopier::class)->disableOriginalConstructor()->getMock();
 
-        $className = '\Magento\Migration\Code\ModuleMigration\ModuleFileExtractor';
-        $moduleFileExtractor = $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+        $moduleFileExtractor = $this->getMockBuilder(ModuleFileExtractor::class)->disableOriginalConstructor()->getMock();
 
-        $className = '\Magento\Migration\Utility\M1\ModuleEnablerConfig';
-        $moduleEnablerConfigFactory = $this->getMockBuilder($className)->disableOriginalConstructor()->getMock();
+        $moduleEnablerConfigFactory = $this->getMockBuilder(ModuleEnablerConfig::class)->disableOriginalConstructor()->getMock();
 
         $this->moduleFileExtractorFactory->expects($this->atLeastOnce())
             ->method('create')
@@ -186,7 +187,7 @@ class ModuleMigrationTest extends \PHPUnit\Framework\TestCase
      * @return array
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
-    public function moveModuleFilesProvider()
+    public function moveModuleFilesProvider(): array
     {
         return [
             [

--- a/tests/unit/Magento/Migration/Code/TestCase.php
+++ b/tests/unit/Magento/Migration/Code/TestCase.php
@@ -15,19 +15,20 @@ use Magento\Migration\Code\Processor\TokenArgumentCollectionFactory;
 use Magento\Migration\Code\Processor\TokenArgumentFactory;
 use Magento\Migration\Code\Processor\TokenHelper;
 use Magento\Migration\Logger\Logger;
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 
-class TestCase extends \PHPUnit\Framework\TestCase
+class TestCase extends PHPUnitTestCase
 {
     /**
      * @param Logger $loggerMock
      * @return TokenHelper
      */
-    public function setupTokenHelper(Logger $loggerMock)
+    public function setupTokenHelper(Logger $loggerMock): TokenHelper
     {
         /** @var ArgumentFactory|PHPUnit_Framework_MockObject_MockObject $argumentFactoryMock */
         $argumentFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\Mage\MageFunction\ArgumentFactory'
+            ArgumentFactory::class
         )->setMethods(['create'])
             ->getMock();
         $argumentFactoryMock->expects($this->any())
@@ -40,7 +41,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
         /** @var TokenArgumentFactory|PHPUnit_Framework_MockObject_MockObject $tokenFactoryMock */
         $tokenFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\TokenArgumentFactory'
+            TokenArgumentFactory::class
         )->setMethods(['create'])
             ->getMock();
         $tokenFactoryMock->expects($this->any())
@@ -53,7 +54,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
         /** @var TokenArgumentCollectionFactory|PHPUnit_Framework_MockObject_MockObject $tokenCollectionFactoryMock */
         $tokenCollectionFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\TokenArgumentCollectionFactory'
+            TokenArgumentCollectionFactory::class
         )->setMethods(['create'])
             ->getMock();
         $tokenCollectionFactoryMock->expects($this->any())
@@ -66,7 +67,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
 
         /** @var CallArgumentCollectionFactory|PHPUnit_Framework_MockObject_MockObject $callCollectionFactoryMock */
         $callCollectionFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\CallArgumentCollectionFactory'
+            CallArgumentCollectionFactory::class
         )->setMethods(['create'])
             ->getMock();
         $callCollectionFactoryMock->expects($this->any())

--- a/tests/unit/Magento/Migration/Code/TokenHelperTest.php
+++ b/tests/unit/Magento/Migration/Code/TokenHelperTest.php
@@ -5,7 +5,12 @@
  */
 namespace Magento\Migration\Code\Processor;
 
-class TokenHelperTest extends \PHPUnit\Framework\TestCase
+use Magento\Migration\Code\Processor\Mage\MageFunction\ArgumentFactory;
+use Magento\Migration\Code\Processor\Mage\MageFunction\Argument;
+use Magento\Migration\Logger\Logger;
+use PHPUnit\Framework\TestCase;
+
+class TokenHelperTest extends TestCase
 {
     /**
      * @var \Magento\Migration\Code\Processor\TokenHelper
@@ -53,61 +58,61 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         }
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->argumentFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\Mage\MageFunction\ArgumentFactory'
+            ArgumentFactory::class
         )->setMethods(['create'])
             ->getMock();
         $this->argumentFactoryMock->expects($this->any())
             ->method('create')
             ->willReturnCallback(
                 function () {
-                    return new \Magento\Migration\Code\Processor\Mage\MageFunction\Argument();
+                    return new Argument();
                 }
             );
         $this->tokenFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\TokenArgumentFactory'
+            TokenArgumentFactory::class
         )->setMethods(['create'])
             ->getMock();
         $this->tokenFactoryMock->expects($this->any())
             ->method('create')
             ->willReturnCallback(
                 function () {
-                    return new \Magento\Migration\Code\Processor\TokenArgument();
+                    return new TokenArgument();
                 }
             );
 
 
         $this->tokenCollectionFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\TokenArgumentCollectionFactory'
+            TokenArgumentCollectionFactory::class
         )->setMethods(['create'])
             ->getMock();
         $this->tokenCollectionFactoryMock->expects($this->any())
             ->method('create')
             ->willReturnCallback(
                 function () {
-                    return new \Magento\Migration\Code\Processor\TokenArgumentCollection();
+                    return new TokenArgumentCollection();
                 }
             );
 
 
         $this->callCollectionFactoryMock = $this->getMockBuilder(
-            '\Magento\Migration\Code\Processor\CallArgumentCollectionFactory'
+            CallArgumentCollectionFactory::class
         )->setMethods(['create'])
             ->getMock();
         $this->callCollectionFactoryMock->expects($this->any())
             ->method('create')
             ->willReturnCallback(
                 function () {
-                    return new \Magento\Migration\Code\Processor\CallArgumentCollection();
+                    return new CallArgumentCollection();
                 }
             );
 
-        $this->loggerMock = $this->getMockBuilder('\Magento\Migration\Logger\Logger')
+        $this->loggerMock = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()->getMock();
 
-        $this->obj = new \Magento\Migration\Code\Processor\TokenHelper(
+        $this->obj = new TokenHelper(
             $this->loggerMock,
             $this->argumentFactoryMock,
             $this->tokenFactoryMock,
@@ -116,7 +121,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    public function testGetNextTokenIndex()
+    public function testGetNextTokenIndex(): void
     {
         $tokens = [
             [T_STRING, 'Mage', 1],
@@ -131,7 +136,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($this->obj->getNextTokenIndex($tokens, 0, 2));
     }
 
-    public function testSkipFunctionCall()
+    public function testSkipFunctionCall(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testSkipFunctionCall');
         $increment = 23;
@@ -142,13 +147,13 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException \Exception
      */
-    public function testSkipFunctionCallNoEnd()
+    public function testSkipFunctionCallNoEnd(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testSkipFunctionCallNoEnd');
         $index = $this->obj->skipMethodCall(self::$tokens, $startingIndex);
     }
 
-    public function testSkipBlock()
+    public function testSkipBlock(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testSkipBlock');
         $increment = 27;
@@ -159,13 +164,13 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException \Exception
      */
-    public function testSkipBlockMismatched()
+    public function testSkipBlockMismatched(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testSkipBlockMismatched');
         $index = $this->obj->skipBlock(self::$tokens, $startingIndex);
     }
 
-    public function testGetNextIndexOfSimpleToken()
+    public function testGetNextIndexOfSimpleToken(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextIndexOfSimpleToken');
         $increment = 8;
@@ -176,13 +181,13 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @expectedException \Exception
      */
-    public function testGetNextIndexOfSimpleTokenNotFound()
+    public function testGetNextIndexOfSimpleTokenNotFound(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextIndexOfSimpleTokenNotFound');
         $index = $this->obj->getNextIndexOfSimpleToken(self::$tokens, $startingIndex, ')');
     }
 
-    public function testGetNextIndexOfTokenType()
+    public function testGetNextIndexOfTokenType(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextIndexOfTokenType');
         $increment = 9;
@@ -195,7 +200,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($startingIndex + $increment, $index);
     }
 
-    public function testGetNextIndexOfTokenTypeNotFound()
+    public function testGetNextIndexOfTokenTypeNotFound(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextIndexOfTokenType');
         $index = $this->obj->getNextIndexOfTokenType(
@@ -207,7 +212,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($index);
     }
 
-    public function testGetPrevIndexOfTokenType()
+    public function testGetPrevIndexOfTokenType(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetPrevIndexOfTokenType');
         $increment = -9;
@@ -220,7 +225,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($startingIndex + $increment, $index);
     }
 
-    public function testGetPrevIndexOfTokenTypeNotFound()
+    public function testGetPrevIndexOfTokenTypeNotFound(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextIndexOfTokenType');
         $index = $this->obj->getPrevIndexOfTokenType(
@@ -232,11 +237,11 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($index);
     }
 
-    public function testGetFunctionArguments()
+    public function testGetFunctionArguments(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetFunctionArguments');
         $arguments = $this->obj->getFunctionArguments(self::$tokens, $startingIndex);
-        $this->assertEquals(4, count($arguments));
+        $this->assertCount(4, $arguments);
 
         $this->assertNull($arguments[0]->getType());
         $this->assertEquals('$input1', $arguments[0]->getName());
@@ -255,14 +260,14 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($arguments[3]->isOptional());
     }
 
-    public function testGetFunctionArgumentsEmpty()
+    public function testGetFunctionArgumentsEmpty(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetFunctionArgumentsEmpty');
         $arguments = $this->obj->getFunctionArguments(self::$tokens, $startingIndex);
         $this->assertEmpty($arguments);
     }
 
-    public function testGetFunctionStartingIndex()
+    public function testGetFunctionStartingIndex(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetFunctionStartingIndex');
         for (; $startingIndex < count(self::$tokens); $startingIndex++) {
@@ -279,7 +284,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($startingIndex + $increment, $index);
     }
 
-    public function testGetFunctionStartingIndexNoDocComment()
+    public function testGetFunctionStartingIndexNoDocComment(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetFunctionStartingIndexNoDocComment');
         for (; $startingIndex < count(self::$tokens); $startingIndex++) {
@@ -296,7 +301,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($startingIndex + $increment, $index);
     }
 
-    public function testGetNextLineIndex()
+    public function testGetNextLineIndex(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetNextLineIndex');
 
@@ -310,7 +315,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
     }
 
-    public function testGetPrevLineIndex()
+    public function testGetPrevLineIndex(): void
     {
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetPrevLineIndex');
 
@@ -324,7 +329,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
     }
 
-    public function testGetCallArguments()
+    public function testGetCallArguments(): void
     {
         //$this->function1($this, 'abc', array ( 'a','b' ), null);
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetCallArguments');
@@ -334,34 +339,34 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
         $argument = $argumentCollection->getArgument(1);
         $tokens = $argument->getTokens();
-        $this->assertEquals(1, count($tokens));
+        $this->assertCount(1, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_VARIABLE, $firstToken->getToken()[0]);
         $this->assertEquals('$this', $firstToken->getToken()[1]);
 
         $argument = $argumentCollection->getArgument(2);
         $tokens = $argument->getTokens();
-        $this->assertEquals(1, count($tokens));
+        $this->assertCount(1, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_CONSTANT_ENCAPSED_STRING, $firstToken->getToken()[0]);
         $this->assertEquals("'abc'", $firstToken->getToken()[1]);
 
         $argument = $argumentCollection->getArgument(3);
         $tokens = $argument->getTokens();
-        $this->assertEquals(6, count($tokens));
+        $this->assertCount(6, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_ARRAY, $firstToken->getToken()[0]);
         $this->assertEquals('array', $firstToken->getToken()[1]);
 
         $argument = $argumentCollection->getArgument(4);
         $tokens = $argument->getTokens();
-        $this->assertEquals(1, count($tokens));
+        $this->assertCount(1, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_STRING, $firstToken->getToken()[0]);
         $this->assertEquals('null', $firstToken->getToken()[1]);
     }
 
-    public function testGetCallArgumentsNoTrim()
+    public function testGetCallArgumentsNoTrim(): void
     {
         //$this->function1($this, 'abc', array ( 'a','b' ), null);
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetCallArguments');
@@ -371,14 +376,14 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
         $argument = $argumentCollection->getArgument(1);
         $tokens = $argument->getTokens();
-        $this->assertEquals(1, count($tokens));
+        $this->assertCount(1, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_VARIABLE, $firstToken->getToken()[0]);
         $this->assertEquals('$this', $firstToken->getToken()[1]);
 
         $argument = $argumentCollection->getArgument(2);
         $tokens = $argument->getTokens();
-        $this->assertEquals(2, count($tokens));
+        $this->assertCount(2, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_WHITESPACE, $firstToken->getToken()[0]);
         $secondToken = array_shift($tokens);
@@ -387,7 +392,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
         $argument = $argumentCollection->getArgument(3);
         $tokens = $argument->getTokens();
-        $this->assertEquals(10, count($tokens));
+        $this->assertCount(10, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_WHITESPACE, $firstToken->getToken()[0]);
         $secondToken = array_shift($tokens);
@@ -396,7 +401,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
         $argument = $argumentCollection->getArgument(4);
         $tokens = $argument->getTokens();
-        $this->assertEquals(3, count($tokens));
+        $this->assertCount(3, $tokens);
         $firstToken = array_shift($tokens);
         $this->assertEquals(T_WHITESPACE, $firstToken->getToken()[0]);
         $secondToken = array_shift($tokens);
@@ -404,7 +409,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('null', $secondToken->getToken()[1]);
     }
 
-    public function testGetCallArgumentsEmpty()
+    public function testGetCallArgumentsEmpty(): void
     {
         //$this->function3( );
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetCallArgumentsEmpty');
@@ -414,7 +419,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
 
     }
 
-    public function testGetCallArgumentsOneArgument()
+    public function testGetCallArgumentsOneArgument(): void
     {
         //$this->function1('abc' );
         $startingIndex = $this->getTestStartIndex(self::$tokens, 'testGetCallArgumentsOneArgument');
@@ -423,7 +428,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(1, $argumentCollection->getCount());
     }
 
-    public function testReplaceCallArgumentsTokens()
+    public function testReplaceCallArgumentsTokens(): void
     {
         $fileContent = file_get_contents(__DIR__ . '/_files/tokenHelperTest.file');
         $tokens = token_get_all($fileContent);
@@ -436,8 +441,8 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         //$this->function1($this, 'abc', array ( 'a','b' ), null);
         $startingIndex = $this->getTestStartIndex($tokens, 'testReplaceCallArgumentsTokens');
 
-        $replacementTokens = new \Magento\Migration\Code\Processor\TokenArgumentCollection();
-        $token = new \Magento\Migration\Code\Processor\TokenArgument();
+        $replacementTokens = new TokenArgumentCollection();
+        $token = new TokenArgument();
         $token->setName('hello');
         $replacementTokens->addToken($token, 0);
         $this->obj->replaceCallArgumentsTokens($tokens, $startingIndex, $replacementTokens);
@@ -448,7 +453,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('hello', $argument->getString());
     }
 
-    public function testReplaceCallArgumentsTokensNoArgument()
+    public function testReplaceCallArgumentsTokensNoArgument(): void
     {
         $fileContent = file_get_contents(__DIR__ . '/_files/tokenHelperTest.file');
         $tokens = token_get_all($fileContent);
@@ -463,8 +468,8 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
             ->method('warn');
         $startingIndex = $this->getTestStartIndex($tokens, 'testReplaceCallArgumentsTokensNoArgument');
 
-        $replacementTokens = new \Magento\Migration\Code\Processor\TokenArgumentCollection();
-        $token = new \Magento\Migration\Code\Processor\TokenArgument();
+        $replacementTokens = new TokenArgumentCollection();
+        $token = new TokenArgument();
         $token->setName('hello');
         $replacementTokens->addToken($token, 0);
         $this->obj->replaceCallArgumentsTokens($tokens, $startingIndex, $replacementTokens);
@@ -477,7 +482,7 @@ class TokenHelperTest extends \PHPUnit\Framework\TestCase
      * @param string $marker
      * @return int|null
      */
-    protected function getTestStartIndex($tokens, $marker)
+    protected function getTestStartIndex($tokens, $marker): ?int
     {
         $marker = '//' . $marker;
         $count = count($tokens);

--- a/tests/unit/Magento/Migration/Mapping/AliasTest.php
+++ b/tests/unit/Magento/Migration/Mapping/AliasTest.php
@@ -5,7 +5,12 @@
  */
 namespace Magento\Migration\Code;
 
-class AliasTest extends \PHPUnit\Framework\TestCase
+use Magento\Migration\Mapping\Context;
+use Magento\Migration\Logger\Logger;
+use Magento\Migration\Mapping\Alias;
+use PHPUnit\Framework\TestCase;
+
+class AliasTest extends TestCase
 {
     /**
      * @var \Magento\Migration\Mapping\Alias
@@ -22,22 +27,22 @@ class AliasTest extends \PHPUnit\Framework\TestCase
      */
     protected $loggerMock;
 
-    public function setUp()
+    protected function setUp(): void
     {
         $this->contextMock = $this->getMockBuilder(
-            '\Magento\Migration\Mapping\Context'
+            Context::class
         )->disableOriginalConstructor()->getMock();
 
-        $this->loggerMock = $this->getMockBuilder('\Magento\Migration\Logger\Logger')
+        $this->loggerMock = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()->getMock();
 
-        $this->obj = new \Magento\Migration\Mapping\Alias(
+        $this->obj = new Alias(
             $this->loggerMock,
             $this->contextMock
         );
     }
 
-    public function testMapAliasNoM1BaseDir()
+    public function testMapAliasNoM1BaseDir(): void
     {
         $this->contextMock->expects($this->once())
             ->method('getM1BaseDir')
@@ -46,7 +51,7 @@ class AliasTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('Mage_Tax_Helper', $this->obj->mapAlias('tax', 'helper'));
     }
 
-    public function testMapAlias()
+    public function testMapAlias(): void
     {
         $baseDir = __DIR__ . '/_files/alias_test';
         $this->contextMock->expects($this->exactly(3))

--- a/tests/unit/Magento/Migration/Mapping/ClassMappingTest.php
+++ b/tests/unit/Magento/Migration/Mapping/ClassMappingTest.php
@@ -5,7 +5,11 @@
  */
 namespace Magento\Migration\Code;
 
-class ClassMappingTest extends \PHPUnit\Framework\TestCase
+use Magento\Migration\Logger\Logger;
+use Magento\Migration\Mapping\ClassMapping;
+use PHPUnit\Framework\TestCase;
+
+class ClassMappingTest extends TestCase
 {
     /**
      * @var \Magento\Migration\Mapping\ClassMapping
@@ -17,17 +21,17 @@ class ClassMappingTest extends \PHPUnit\Framework\TestCase
      */
     protected $loggerMock;
 
-    public function setUp()
+    protected function setUp(): void
     {
-        $this->loggerMock = $this->getMockBuilder('\Magento\Migration\Logger\Logger')
+        $this->loggerMock = $this->getMockBuilder(Logger::class)
             ->disableOriginalConstructor()->getMock();
 
-        $this->obj = new \Magento\Migration\Mapping\ClassMapping(
+        $this->obj = new ClassMapping(
             $this->loggerMock
         );
     }
 
-    public function testMapM1Class()
+    public function testMapM1Class(): void
     {
         $this->assertEquals("\\Magento\\Backend\\Helper\\Data", $this->obj->mapM1Class('Mage_Admin_Helper_Data'));
         $this->assertEquals(


### PR DESCRIPTION
# Changed log
- Enhancement for part of classes
- According to the [PHPUnit fixture reference](https://phpunit.de/manual/6.5/en/fixtures.html), the `setUp` method should be `protected` with `: void` type hint.
- Add native type hint for part of test classes.
- Using the `assertCount` to assert expected array length is same as result.
- To be consistency, letting namespaces be declared on the head of PHP files.